### PR TITLE
Supporting webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	},
 	"name": "nativescript-okhttp",
 	"version": "0.0.8",
-	"main": "nativescript-okhttp.js",
+	"main": "nativescript-okhttp",
 	"nativescript": {
 		"platforms": {
 			"android": "1.4.0"


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson